### PR TITLE
Run on xcode12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 setup:bootstrap install-pod
 
 bootstrap:
-	carthage bootstrap --platform iOS --cache-builds
+	# carthage bootstrap --platform iOS --cache-builds
+	./carthage.sh bootstrap --platform iOS --cache-builds
 
 update-pod:install-gem
 	bundle exec pod repo update

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			dependencies = (
 			);
 			name = SwiftFormat;
+			productName = SwiftFormat;
 		};
 		52B60EC2A583F24ACBB69C113F5488B9 /* SwiftLint */ = {
 			isa = PBXAggregateTarget;
@@ -24,6 +25,7 @@
 			dependencies = (
 			);
 			name = SwiftLint;
+			productName = SwiftLint;
 		};
 /* End PBXAggregateTarget section */
 
@@ -53,12 +55,12 @@
 /* Begin PBXFileReference section */
 		06B70D97160FECA378C9DABFBBDC0B14 /* SwiftLint.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftLint.xcconfig; sourceTree = "<group>"; };
 		1B509324E0DDBFAF6F9BDEE03557A200 /* Pods-Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		1F667CC0E19EAF34E5A4119E2121F585 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Example.framework; path = "Pods-Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F667CC0E19EAF34E5A4119E2121F585 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		37E86C8334F06C336630A870A0B2E62F /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		549ECE3D4A5A2BA1051A53148D21494E /* SwiftFormat.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftFormat.xcconfig; sourceTree = "<group>"; };
 		6A5BCFDC8A0BFCCF78D79352ECBE4D05 /* Pods-Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A26EC3A56CC4AB6876A51526A56D550E /* Pods-Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Example-umbrella.h"; sourceTree = "<group>"; };
 		A38A5498DFA72D80A29954DFC52440DA /* Pods-Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Example-Info.plist"; sourceTree = "<group>"; };
 		F136FFE8A9F77E570AF1D4CFBD7CF333 /* Pods-Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Example-dummy.m"; sourceTree = "<group>"; };
@@ -108,7 +110,6 @@
 			children = (
 				4A93726AF8E11A1BEB3E6F8D5D6D533B /* Support Files */,
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -143,7 +144,6 @@
 			children = (
 				8930EC6D1973325C6724E7FC84A890A0 /* Support Files */,
 			);
-			name = SwiftFormat;
 			path = SwiftFormat;
 			sourceTree = "<group>";
 		};
@@ -297,7 +297,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-Example/Pods-Example-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -325,7 +325,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -342,7 +342,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -369,7 +369,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "Target Support Files/Pods-Example/Pods-Example-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -438,7 +438,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -501,7 +501,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -520,7 +520,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -536,7 +536,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/RxMusicPlayer/RxMusicPlayer+Rx.swift
+++ b/RxMusicPlayer/RxMusicPlayer+Rx.swift
@@ -160,7 +160,7 @@ extension Reactive where Base: RxMusicPlayer {
             .asObservable()
             .flatMapLatest { item in
                 item.rx.loadedTimeRanges
-                    .map { $0.last as? CMTimeRange }
+                    .map { $0.last?.timeRangeValue }
             }
             .asDriver(onErrorJustReturn: nil)
     }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,9 +15,17 @@ workflows:
     - git-clone@4.0.11: {}
     - cache-pull@2.0.1: {}
     - certificate-and-profile-installer@1.9.3: {}
-    - carthage@3:
+    - script@1:
         inputs:
-        - carthage_options: "--platform ios --cache-builds"
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+
+            # write your script here
+            ./carthage.sh bootstrap --platform iOS --cache-builds
     - xcode-test@1.18.14:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,7 +26,7 @@ workflows:
 
             # write your script here
             ./carthage.sh bootstrap --platform iOS --cache-builds
-    - xcode-test@1.18.14:
+    - xcode-test@2.4:
         inputs:
         - project_path: "$BITRISE_PROJECT_PATH"
         - scheme: "$BITRISE_SCHEME"

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+## https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
Local log when setting up from scratch.

```
/tmp ❯❯❯ git@github.com:yoheimuta/RxMusicPlayer.git

/tmp ❯❯❯ git clone git@github.com:yoheimuta/RxMusicPlayer.git
Cloning into 'RxMusicPlayer'...
remote: Enumerating objects: 51, done.
remote: Counting objects: 100% (51/51), done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 868 (delta 22), reused 31 (delta 13), pack-reused 817
Receiving objects: 100% (868/868), 97.71 MiB | 2.27 MiB/s, done.
Resolving deltas: 100% (456/456), done.

/tmp ❯❯❯ cd RxMusicPlayer

/t/RxMusicPlayer ❯❯❯ env - PATH=$PATH make setup
# carthage bootstrap --platform iOS --cache-builds
./carthage.sh bootstrap --platform iOS --cache-builds
Please update to the latest Carthage version: 0.36.0. You currently are on 0.35.0
*** Checking out RxSwift at "5.0.1"
*** No cache found for RxSwift, building with all downstream dependencies
*** xcodebuild output can be found in /var/folders/yj/0nkt3j750nz3x582dpf84r3w0000gn/T/carthage-xcodebuild.MDRZkY.log
*** Downloading RxSwift.framework binary at "ShaiTheBravest"
***  Skipped installing RxSwift.framework binary due to the error:
        "Incompatible Swift version - framework was built with 5.0.1 (swiftlang-1001.0.82.4 clang-1001.0.46.5) and the local version is 5.3 (swiftlang-1200.0.29.2 clang-1200.0.30.1)."

    Falling back to building from the source
*** Building scheme "RxBlocking" in Rx.xcworkspace
*** Building scheme "RxRelay" in Rx.xcworkspace
*** Building scheme "RxCocoa" in Rx.xcworkspace
*** Building scheme "RxSwift" in Rx.xcworkspace
*** Building scheme "RxTest" in Rx.xcworkspace
bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/.......
Fetching CFPropertyList 3.0.1
Installing CFPropertyList 3.0.1
Fetching concurrent-ruby 1.1.5
Installing concurrent-ruby 1.1.5
Fetching i18n 0.9.5
Installing i18n 0.9.5
Fetching minitest 5.11.3
Installing minitest 5.11.3
Fetching thread_safe 0.3.6
Installing thread_safe 0.3.6
Fetching tzinfo 1.2.5
Installing tzinfo 1.2.5
Fetching activesupport 4.2.11.1
Installing activesupport 4.2.11.1
Fetching atomos 0.1.3
Installing atomos 0.1.3
Using bundler 1.17.3
Fetching claide 1.0.3
Installing claide 1.0.3
Fetching fuzzy_match 2.0.4
Installing fuzzy_match 2.0.4
Fetching nap 1.1.0
Installing nap 1.1.0
Fetching cocoapods-core 1.7.5
Installing cocoapods-core 1.7.5
Fetching cocoapods-deintegrate 1.0.4
Installing cocoapods-deintegrate 1.0.4
Fetching cocoapods-downloader 1.2.2
Installing cocoapods-downloader 1.2.2
Fetching cocoapods-plugins 1.0.0
Installing cocoapods-plugins 1.0.0
Fetching cocoapods-search 1.0.0
Installing cocoapods-search 1.0.0
Fetching cocoapods-stats 1.1.0
Installing cocoapods-stats 1.1.0
Fetching netrc 0.11.0
Installing netrc 0.11.0
Fetching cocoapods-trunk 1.4.0
Installing cocoapods-trunk 1.4.0
Fetching cocoapods-try 1.1.0
Installing cocoapods-try 1.1.0
Fetching colored2 3.1.2
Installing colored2 3.1.2
Fetching escape 0.0.4
Installing escape 0.0.4
Fetching fourflusher 2.3.1
Installing fourflusher 2.3.1
Fetching gh_inspector 1.1.3
Installing gh_inspector 1.1.3
Fetching molinillo 0.6.6
Installing molinillo 0.6.6
Fetching ruby-macho 1.4.0
Installing ruby-macho 1.4.0
Fetching nanaimo 0.2.6
Installing nanaimo 0.2.6
Fetching xcodeproj 1.12.0
Installing xcodeproj 1.12.0
Fetching cocoapods 1.7.5
Installing cocoapods 1.7.5
Bundle complete! 1 Gemfile dependency, 30 gems now installed.
Bundled gems are installed into `./vendor/bundle`
bundle exec pod install
    WARNING: CocoaPods requires your terminal to be using UTF-8 encoding.
    Consider adding the following to ~/.profile:

    export LANG=en_US.UTF-8

Analyzing dependencies
Downloading dependencies
Using SwiftFormat (0.32.2)
Using SwiftLint (0.35.0)
Generating Pods project
Integrating client project
Sending stats
Pod installation complete! There are 2 dependencies from the Podfile and 2 total pods installed.

/t/RxMusicPlayer ❯❯❯ open RxMusicPlayer.xcworkspace 
```