### PR TITLE
Prevent a crash if user press next too fast and many times

### DIFF
--- a/RxMusicPlayer/RxMusicPlayer.swift
+++ b/RxMusicPlayer/RxMusicPlayer.swift
@@ -200,8 +200,8 @@ open class RxMusicPlayer: NSObject {
     let desiredPlaybackRateRelay = BehaviorRelay<Float>(value: 1.0)
     let remoteControlRelay = BehaviorRelay<RemoteControl>(value: .moveTrack)
 
-    private let scheduler = ConcurrentDispatchQueueScheduler(
-        queue: DispatchQueue.global(qos: .background)
+    private let scheduler = SerialDispatchQueueScheduler(
+        queue: DispatchQueue.global(qos: .background), internalSerialQueueName: "RxMusicPlayerSerialQueue"
     )
     public private(set) var player: AVPlayer? {
         set {


### PR DESCRIPTION
ref. https://github.com/yoheimuta/RxMusicPlayer/issues/21#issuecomment-860443895

The reproduced local log is following.
I confirmed the other thread entered the play function and set the player to nil while the crashed thread tried to unwrap the player.

```
ready
readyToPlay
loading
RxMusicPlayer/RxMusicPlayer.swift:577: Fatal error: Unexpectedly found nil while unwrapping an Optional value
2022-06-25 12:44:43.924432+0900 ExampleSwiftUI[82068:13633583] RxMusicPlayer/RxMusicPlayer.swift:577: Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

The play function is called within ConcurrentDispatchQueueScheduler, so it can run concurrently.
It's critical to perform this blocking operation in the background thread, but it must be enough to run serially.